### PR TITLE
Revert "chore: CIでNode v18を使用する"

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,8 +15,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
-          cache: yarn
+          node-version: 16.x
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Lint
@@ -30,8 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
-          cache: yarn
+          node-version: 16.x
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Build


### PR DESCRIPTION
Reverts twinkle-tsukuba/docs#153

Webpackからエラーが投げられてしまうので16系に戻したいと思います。

`Error: error:0308010C:digital envelope routines::unsupported`